### PR TITLE
Prevent trying to use None as str in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import os
 
 import secret_token
 
-API_TOKEN = secret_token.decode(os.environ.get("API_TOKEN"))
+API_TOKEN = secret_token.decode(os.environ["API_TOKEN"])
 ```
 
 [rfc8959]: https://tools.ietf.org/html/rfc8959 "The \"secret-token\" URI Scheme"


### PR DESCRIPTION
The decode() function doesn't accept None so it's better to crash on
os.environ[] than further down the line with a confusing error message.